### PR TITLE
Replace Travis CI configuration with a similar GitHub action, swap badge

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,36 @@
+name: CI
+
+on:
+  push: ~
+  pull_request: ~
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+
+    name: "PHP ${{ matrix.php }}, Monolog ${{ matrix.monolog }}"
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: [ "7.4", "8.0", "8.1" ]
+        monolog: [ "^1.17", "^2.0" ]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Set up PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "${{ matrix.php }}"
+          tools: composer
+
+      - name: Restrict Monolog
+        run: "composer require --no-install monolog/monolog=${{ matrix.monolog }}"
+
+      - name: Install dependencies
+        run: composer install --prefer-dist
+
+      - name: Run PHPUnit
+        run: vendor/bin/phpunit --colors=always

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,0 @@
-language: php
-php:
-  - '7.4'
-  - '8.0'
-  - '8.1'
-
-install:
-  - composer install --prefer-dist

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# monolog-gdpr [![Build Status](https://travis-ci.org/egeniq/monolog-gdpr.svg?branch=develop)](https://travis-ci.org/egeniq/monolog-gdpr)
+# monolog-gdpr [![Build Status](https://github.com/egeniq/monolog-gdpr/actions/workflows/ci.yaml/badge.svg?branch=develop)](https://github.com/egeniq/monolog-gdpr/actions/workflows/ci.yaml)
 Some Monolog processors that will help in relation to the security requirements under GDPR.
 These processors will replace data with their SHA-1 equivalent, allowing you still to search 
 logs


### PR DESCRIPTION
Travis-CI no longer builds anything on travis-ci.org, so the badge in the README is now misleading. This PR replaces .travis.yml with similar GitHub Actions setup.