### PR TITLE
Fix TypeError and refactor processors

### DIFF
--- a/src/Processor/AbstractProcessor.php
+++ b/src/Processor/AbstractProcessor.php
@@ -1,30 +1,53 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Egeniq\Monolog\Gdpr\Processor;
 
 use Monolog\Processor\ProcessorInterface;
 
 abstract class AbstractProcessor implements ProcessorInterface
 {
-    /**
-     * @var null|string
-     */
-    private $salt;
+    private string $salt = '';
 
-    /**
-     * @param string $salt
-     */
     public function setSalt(string $salt): void
     {
         $this->salt = $salt;
     }
 
     /**
-     * @param string $value
-     *
-     * @return string
+     * NOTE: the signature of this method will change when support for Monolog 3 is added.
      */
-    protected function getHashedValue(string $value)
+    public function __invoke(array $record): array
+    {
+        return $this->redactValuesRecursively($record);
+    }
+
+    private function redactValuesRecursively(array $record): array
+    {
+        foreach ($record as $key => $value) {
+            if (is_string($value)) {
+                $record[$key] = $this->redactStringValue($value);
+            } elseif (is_array($value)) {
+                $record[$key] = $this->redactValuesRecursively($value);
+            }
+        }
+
+        return $record;
+    }
+
+    private function redactStringValue(string $record): string
+    {
+        return preg_replace_callback(
+            static::REGEX_PATTERN,
+            function (array $matches): string {
+                return $this->getHashedValue($matches[0]);
+            },
+            $record
+        ) ?? $record;
+    }
+
+    private function getHashedValue(string $value): string
     {
         return sha1($value . $this->salt);
     }

--- a/src/Processor/RedactEmailProcessor.php
+++ b/src/Processor/RedactEmailProcessor.php
@@ -1,31 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Egeniq\Monolog\Gdpr\Processor;
 
 class RedactEmailProcessor extends AbstractProcessor
 {
-    /**
-     * @param array $record
-     *
-     * @return array
-     */
-    public function __invoke(array $record): array
-    {
-        // serialise to a JSON string so we can scan the entire tree
-        $serialised = json_encode($record);
-
-        $filtered = preg_replace_callback(
-            "/([a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`\"\"{|}~-]+)*(@|\sat\s)(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(\.|\"\"\sdot\s))+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)/",
-            function ($matches) {
-                return $this->getHashedValue($matches[0]);
-            },
-            $serialised
-        );
-
-        if ($filtered) {
-            return json_decode($filtered, true);
-        }
-
-        return $record;
-    }
+    protected const REGEX_PATTERN = "/([a-z0-9!#$%&'*+\/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+\/=?^_`\"\"{|}~-]+)*(@|\sat\s)(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?(\.|\"\"\sdot\s))+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?)/";
 }

--- a/src/Processor/RedactIpProcessor.php
+++ b/src/Processor/RedactIpProcessor.php
@@ -1,31 +1,10 @@
 <?php
 
+declare(strict_types=1);
+
 namespace Egeniq\Monolog\Gdpr\Processor;
 
 class RedactIpProcessor extends AbstractProcessor
 {
-    /**
-     * @param array $record
-     *
-     * @return array
-     */
-    public function __invoke(array $record): array
-    {
-        // serialise to a JSON string so we can scan the entire tree
-        $serialised = json_encode($record);
-
-        $filtered = preg_replace_callback(
-            "/(\b\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3}\b)/",
-            function($matches) {
-                return $this->getHashedValue($matches[0]);
-            },
-            $serialised
-        );
-
-        if ($filtered) {
-            return json_decode($filtered, true);
-        }
-
-        return $record;
-    }
+    protected const REGEX_PATTERN = "/(\b\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3}\b)/";
 }

--- a/tests/Processor/RedactEmailProcessorTest.php
+++ b/tests/Processor/RedactEmailProcessorTest.php
@@ -67,4 +67,20 @@ class RedactEmailProcessorTest extends TestCase
             $records[0]['context']
         );
     }
+
+    public function testEmailIsRedactedInProblematicString()
+    {
+        $this->logger->log(Logger::DEBUG, '(1,	\'foo@bar.com\')', ['foo' => ['bar' => 'foo@bar.com']]);
+        $records = $this->handler->getRecords();
+
+        $this->assertEquals('(1,	40d36e2e19ba403439bdf6ad32d294d530ff0ec7\')', $records[0]['message']);
+        $this->assertEquals(
+            [
+                'foo' => [
+                    'bar' => '823776525776c8f23a87176c59d25759da7a52c4'
+                ]
+            ],
+            $records[0]['context']
+        );
+    }
 }


### PR DESCRIPTION
One of the current processors caused one of our CI steps to fail like this during the build:

```In RedactEmailProcessor.php line 26:
  [TypeError]                                                                  
  Egeniq\Monolog\Gdpr\Processor\RedactEmailProcessor::__invoke(): Return value must be of type array, null returned                                       
```

I didn't really try reproducing that locally (too much hassle), but my first instinct is to blame current code of the Processor in question, which first converts the whole array into a JSON string, then performs a `preg_replace_callback` on that string, and then attempts to convert the string back to an array, and doesn't even check the result. Thus I decided to refactor these processors to employ a cycle and a recursion instead. While doing this, I also noticed that the code of both of the processors is basically the same, with the exception of the regex that is used. So I figured why not move everything into the abstract class and just have a single constant in both final processors. WDYT?

BTW, I also have a separate branch where I'm working on Monolog 3 support, but Seldaek/monolog#1680 is currently blocking me. :)